### PR TITLE
Rename "accounts.admins" field to "accounts.hosts" to be consistent with previous design decisions

### DIFF
--- a/examples/one.toml
+++ b/examples/one.toml
@@ -27,7 +27,7 @@ python3 = "latest"
 java = "21"
 ocaml = { build = "ocamlc -o out solution.ml", run = "./out", source_file = "solution.ml" }
 
-[[accounts.admins]]
+[[accounts.hosts]]
 name = "Teacher"
 password = "abc123"
 

--- a/examples/render-test.toml
+++ b/examples/render-test.toml
@@ -11,7 +11,7 @@ python3 = "latest"
 java = "21"
 ocaml = { build = "ocamlc -o out solution.ml", run = "./out", source_file = "solution.ml" }
 
-[[accounts.admins]]
+[[accounts.hosts]]
 name = "Teacher"
 password = "abc123"
 

--- a/examples/uil.toml
+++ b/examples/uil.toml
@@ -11,7 +11,7 @@ max_file_size = 8192
 python3 = "latest"
 java = "21"
 
-[[accounts.admins]]
+[[accounts.hosts]]
 name = "Teacher"
 password = "abc123"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ pub(crate) fn default_port() -> u16 {
     8517
 }
 
-/// Authentication details for a specific user (competitor or admin)
+/// Authentication details for a specific user (competitor or host)
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Default)]
 #[serde(deny_unknown_fields)]
 pub struct User {
@@ -43,8 +43,8 @@ pub struct User {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Default)]
 #[serde(deny_unknown_fields)]
 pub struct Accounts {
-    /// Administrators in charge of managing the competition
-    pub admins: Vec<User>,
+    /// Hosts in charge of managing the competition
+    pub hosts: Vec<User>,
     /// Competitors participating in the competition
     pub competitors: Vec<User>,
 }

--- a/tests/hashing.rs
+++ b/tests/hashing.rs
@@ -43,7 +43,7 @@ fn whitespace_diff() {
     let a = Config::from_str(
         r#"
 port = 80
-accounts.admins = []
+accounts.hosts = []
 accounts.competitors = []
 [languages]
 python3 = "latest"
@@ -66,7 +66,7 @@ problems = []
     let b = Config::from_str(
         r#"
 port = 80
-accounts.admins = []
+accounts.hosts = []
 accounts.competitors = []
 # Specify information a
 [packet]

--- a/tests/imports.toml
+++ b/tests/imports.toml
@@ -8,7 +8,7 @@ python3 = "latest"
 java = "21"
 ocaml = { build = "ocamlc -o out solution.ml", run = "./out", source_file = "solution.ml" }
 
-[[accounts.admins]]
+[[accounts.hosts]]
 name = "Teacher"
 password = "abc123"
 


### PR DESCRIPTION
Will have a similar PR in basalt-server for the bedrock change and updating the role name once this is complete.