### PR TITLE
deprecate event-handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ target/
 # Examples output
 *.pdf
 *.html
+
+.direnv/

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -1,4 +1,4 @@
-use serde::{de::IgnoredAny, Deserialize, Deserializer, Serialize};
+use serde::{de::IgnoredAny, Deserialize, Serialize};
 use serde_with::{serde_as, OneOrMany};
 use url::Url;
 
@@ -11,20 +11,10 @@ pub struct Integrations {
     #[serde(
         default,
         alias = "event_handler",
-        deserialize_with = "deserialize_deprecated"
     )]
     #[deprecated(since = "1.1.0", note = "Deprecated in favor of webhooks")]
-    pub event_handlers: (),
+    pub event_handlers: IgnoredAny,
     #[serde_as(as = "OneOrMany<_>")]
     #[serde(default, alias = "webhook")]
     pub webhooks: Vec<Url>,
-}
-
-fn deserialize_deprecated<'de, D>(deserializer: D) -> Result<(), D::Error>
-where
-    D: Deserializer<'de>,
-{
-    // Consume and discard whatever value is there
-    IgnoredAny::deserialize(deserializer)?;
-    Ok(())
 }

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -13,7 +13,7 @@ pub struct Integrations {
         alias = "event_handler",
         deserialize_with = "deserialize_deprecated"
     )]
-    #[deprecated(since = "1.0.1", note = "Deprecated in favor of webhooks")]
+    #[deprecated(since = "1.1.0", note = "Deprecated in favor of webhooks")]
     pub event_handlers: (),
     #[serde_as(as = "OneOrMany<_>")]
     #[serde(default, alias = "webhook")]

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -8,11 +8,7 @@ use url::Url;
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Integrations {
     /// Paths to files that will be executed on server events
-    #[serde(
-        default,
-        skip,
-        alias = "event_handler",
-    )]
+    #[serde(default, skip, alias = "event_handler")]
     #[deprecated(since = "1.1.0", note = "Deprecated in favor of webhooks")]
     pub event_handlers: (),
     #[serde_as(as = "OneOrMany<_>")]

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -1,4 +1,4 @@
-use serde::{de::IgnoredAny, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, OneOrMany};
 use url::Url;
 
@@ -10,10 +10,11 @@ pub struct Integrations {
     /// Paths to files that will be executed on server events
     #[serde(
         default,
+        skip,
         alias = "event_handler",
     )]
     #[deprecated(since = "1.1.0", note = "Deprecated in favor of webhooks")]
-    pub event_handlers: IgnoredAny,
+    pub event_handlers: (),
     #[serde_as(as = "OneOrMany<_>")]
     #[serde(default, alias = "webhook")]
     pub webhooks: Vec<Url>,

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -1,6 +1,4 @@
-use std::path::PathBuf;
-
-use serde::{Deserialize, Serialize};
+use serde::{de::IgnoredAny, Deserialize, Deserializer, Serialize};
 use serde_with::{serde_as, OneOrMany};
 use url::Url;
 
@@ -10,10 +8,23 @@ use url::Url;
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Integrations {
     /// Paths to files that will be executed on server events
-    #[serde_as(as = "OneOrMany<_>")]
-    #[serde(default, alias = "event_handler")]
-    pub event_handlers: Vec<PathBuf>,
+    #[serde(
+        default,
+        alias = "event_handler",
+        deserialize_with = "deserialize_deprecated"
+    )]
+    #[deprecated(since = "1.0.1", note = "Deprecated in favor of webhooks")]
+    pub event_handlers: (),
     #[serde_as(as = "OneOrMany<_>")]
     #[serde(default, alias = "webhook")]
     pub webhooks: Vec<Url>,
+}
+
+fn deserialize_deprecated<'de, D>(deserializer: D) -> Result<(), D::Error>
+where
+    D: Deserializer<'de>,
+{
+    // Consume and discard whatever value is there
+    IgnoredAny::deserialize(deserializer)?;
+    Ok(())
 }

--- a/tests/events-are-optional.toml
+++ b/tests/events-are-optional.toml
@@ -1,0 +1,106 @@
+# Adapted from https://www.uiltexas.org/files/academics/Mitra_CompSci_District_2018_Programming_Packet.pdf
+port = 8517
+web_client = true
+
+[test_runner]
+timeout = "60s"
+trim_output = true
+max_memory = { compile = 128, run = 64 }
+max_file_size = 8192
+
+[integrations]
+webhooks = "http://localhost:8080"
+
+[game]
+score = "points - 2*max(completed, attempts)"
+
+[languages]
+python3 = "latest"
+java = "21"
+
+[[accounts.hosts]]
+name = "host"
+password = "pwd1"
+
+[[accounts.competitors]]
+name = "team1"
+password = "pwd1"
+
+[[accounts.competitors]]
+name = "team2"
+password = "pwd1"
+
+# Specify information about the packet itself
+[packet]
+title = "UIL Computer Science Competition District 2018 Programming Problem Set"
+preamble = '''
+**Note: This is adapted from <https://www.uiltexas.org/files/academics/Mitra_CompSci_District_2018_Programming_Packet.pdf>**
+
+# General Notes
+
+1. Do the problems in any order you like. They do not have to be done in order from 1 to 12.
+2. All problems have a value of 60 points.
+3. There is no extraneous input. All input is exactly as specified in the problem. Unless specified by the problem, integer inputs will not have leading zeros. Unless otherwise specified, your program should read to the end of file.
+4. Your program should not print extraneous output. Follow the form exactly as given in the problem.
+5. A penalty of 5 points will be assessed each time that an incorrect solution is submitted. This penalty will only be assessed if a solution is ultimately judged as correct.
+
+# Names of Problems
+
+ | Number         | Name     |
+ | -------------- | -------- |
+ | Problem 1      | Alice    |
+ | Problem 2      | Bayani   |
+ | Problem 3      | Candela  |
+ | Problem 4      | Carla    |
+ | Problem 5      | Diya     |
+ | ~~Problem 6~~  | ~~Gleb~~ |
+ | Problem 7      | Jeremy   |
+ | Problem 8      | Kinga    |
+ | Problem 9      | Layla    |
+ | Problem 10     | Max      |
+ | Problem 11     | Nandita  |
+ | Problem 12     | Raymond  |
+
+'''
+
+[[packet.problems]]
+points = 10
+# import = "./problem1.toml"
+title = "Alice"
+description = '''
+Alice is waving to you from her sailboat! Write a program to output this image, exactly as you see it.
+
+**Input:** None
+**Output:** A picture of Alice in her sailboat, having fun out on the water.
+'''
+
+[[packet.problems.tests]]
+input = ""
+output = '''
+            &
+            &&
+            &&&
+            &&-&
+            &&--&
+            &&---&
+            &&----&
+            &&--.--&
+            &&--..--&
+            &&--...--&
+            &&--....--&
+            &&--.....--&
+            &&--......--&
+            &&--.......--&
+            &&--........--&
+            &&--.........--&
+            &&--..........--&
+            &&--...........--&
+            &&--............--&
+            &&--.............--&
+            || \o/
+            ||  |
+ ======================================
+   ==================================
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+'''
+visible = true

--- a/tests/integrations.rs
+++ b/tests/integrations.rs
@@ -7,7 +7,6 @@ const ONE_FILE: &str = include_str!("../examples/one.toml");
 #[test]
 fn parse_empty_integration_settings() -> miette::Result<()> {
     let config = Config::from_str(ONE_FILE, Some("one.toml"))?;
-    assert_eq!(config.integrations.event_handlers.len(), 0);
     assert_eq!(config.integrations.webhooks.len(), 0);
     Ok(())
 }
@@ -15,7 +14,6 @@ fn parse_empty_integration_settings() -> miette::Result<()> {
 #[test]
 fn parse_multiple() -> miette::Result<()> {
     let config = Config::from_str(FILE, Some("events.toml"))?;
-    assert_eq!(config.integrations.event_handlers.len(), 2);
     assert_eq!(config.integrations.webhooks.len(), 2);
     Ok(())
 }
@@ -23,7 +21,6 @@ fn parse_multiple() -> miette::Result<()> {
 #[test]
 fn parse_single() -> miette::Result<()> {
     let config = Config::from_str(FILE_SINGLE, Some("events-single.toml"))?;
-    assert_eq!(config.integrations.event_handlers.len(), 1);
     assert_eq!(config.integrations.webhooks.len(), 1);
     Ok(())
 }

--- a/tests/integrations.rs
+++ b/tests/integrations.rs
@@ -3,11 +3,18 @@ use basalt_bedrock::Config;
 const FILE: &str = include_str!("./events.toml");
 const FILE_SINGLE: &str = include_str!("./events-single.toml");
 const ONE_FILE: &str = include_str!("../examples/one.toml");
+const NO_EVENTS: &str = include_str!("./events-are-optional.toml");
 
 #[test]
 fn parse_empty_integration_settings() -> miette::Result<()> {
     let config = Config::from_str(ONE_FILE, Some("one.toml"))?;
     assert_eq!(config.integrations.webhooks.len(), 0);
+    Ok(())
+}
+
+#[test]
+fn parse_no_handlers() -> miette::Result<()> {
+    let _ = Config::from_str(NO_EVENTS, Some("events-are-optional.toml"))?;
     Ok(())
 }
 


### PR DESCRIPTION
deprecating in favor of `integrations.webhooks`

Close #58 